### PR TITLE
Fix discord connected spam

### DIFF
--- a/src/health/HealthCheckServer.ts
+++ b/src/health/HealthCheckServer.ts
@@ -135,7 +135,10 @@ export class HealthCheckServer {
             this.discordStatus.reconnectCount++;
         }
 
-        Logger.info(`🏥 Health status updated: Discord ${connected ? 'connected' : 'disconnected'}`);
+        // Only log when the connection status actually changes
+        if (wasConnected !== connected) {
+            Logger.info(`🏥 Health status updated: Discord ${connected ? 'connected' : 'disconnected'}`);
+        }
     }
 
     /**


### PR DESCRIPTION
# Fix discord connected spam

## Problem
The `🏥 Health status updated: Discord connected` is spammed in logs

The problem is that it's logging on every heartbeat, not only when reconnected

## Solution
<!-- List the key changes you made to solve the problem -->
<!-- Use bullet points for clarity -->
- Added a simple if-statement to only log when connection was resumed

## Testing
<!-- Check off what you've tested - add more items as needed -->
- [x] Tested locally
- [x] Verified the fix works as expected
- [x] No breaking changes introduced
- [x] Documentation updated (if needed)

<!-- Link any issues this PR closes -->
Closes #8
<!-- You can also use: Fixes #, Resolves #, or remove this line if no issues -->